### PR TITLE
debian: drop versioned dependency on gzip

### DIFF
--- a/install/debian/control
+++ b/install/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Standards-Version: 4.5.0
 Build-Depends:  libc6 (>= 2.3.2), 
                 golang-1.16, 
-                gzip (>=1.10), 
+                gzip,
                 ronn, 
                 debhelper (>=12.10),
                 golang-any,
@@ -18,7 +18,7 @@ Build-Depends:  libc6 (>= 2.3.2),
 
 Package: samba-exporter
 Architecture: amd64
-Depends: libc6 (>= 2.3.2), samba, systemd, gzip (>=1.10)
+Depends: libc6 (>= 2.3.2), samba, systemd, gzip
 Enhances: samba
 Description: Prometheus exporter to get metrics of a samba server
   This is a prometheus exporter to get metrics of a samba server. 


### PR DESCRIPTION
There's no need to depend on gzip >=1.10, so drop the versioned Build-Depends and Depends on it.

FTR: verified on Debian GNU/Linux 9.13 (stretch) system, with gzip 1.6-5+deb9u1.

Thanks for samba_exporter, and also providing a Debian package! :partying_face: 