### PR TITLE
feat: Create packages for Ubuntu 23.10 and Fedora 39

### DIFF
--- a/.github/workflows/release-jobs.yml
+++ b/.github/workflows/release-jobs.yml
@@ -211,14 +211,14 @@ jobs:
         asset_path: bin/rpm-packages/Fedora-35/samba-exporter-${{ env.SAMBA_EXPORTER_RELEASE_TAG }}-1.fc35.x86_64.rpm 
         asset_name: samba-exporter-${{ env.SAMBA_EXPORTER_RELEASE_TAG }}-1.fc35.x86_64.rpm 
         asset_content_type: application/zip                   
-    - name: Upload Release Asset for Fedora 37
+    - name: Upload Release Asset for Fedora 39
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ env.SAMBA_EXPORTER_UPLOAD_URL }}
-        asset_path: bin/rpm-packages/Fedora-37/samba-exporter-${{ env.SAMBA_EXPORTER_RELEASE_TAG }}-1.fc37.x86_64.rpm 
-        asset_name: samba-exporter-${{ env.SAMBA_EXPORTER_RELEASE_TAG }}-1.fc37.x86_64.rpm 
+        asset_path: bin/rpm-packages/Fedora-39/samba-exporter-${{ env.SAMBA_EXPORTER_RELEASE_TAG }}-1.fc39.x86_64.rpm 
+        asset_name: samba-exporter-${{ env.SAMBA_EXPORTER_RELEASE_TAG }}-1.fc39.x86_64.rpm 
         asset_content_type: application/zip  
     - name: Upload Release Asset for Fedora 38
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-jobs.yml
+++ b/.github/workflows/release-jobs.yml
@@ -94,14 +94,14 @@ jobs:
         asset_path: ./bin/deb-packages/binary/samba-exporter_${{ env.SAMBA_EXPORTER_RELEASE_TAG }}~ppa1~ubuntu20.04_amd64.deb
         asset_name: samba-exporter_${{ env.SAMBA_EXPORTER_RELEASE_TAG }}~ppa1~ubuntu20.04_amd64.deb
         asset_content_type: application/zip    
-    - name: Upload Release Asset for Ubuntu 23.04
+    - name: Upload Release Asset for Ubuntu 23.10
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ env.SAMBA_EXPORTER_UPLOAD_URL }}
-        asset_path: ./bin/deb-packages/binary/samba-exporter_${{ env.SAMBA_EXPORTER_RELEASE_TAG }}~ppa1~ubuntu23.04_amd64.deb
-        asset_name: samba-exporter_${{ env.SAMBA_EXPORTER_RELEASE_TAG }}~ppa1~ubuntu23.04_amd64.deb
+        asset_path: ./bin/deb-packages/binary/samba-exporter_${{ env.SAMBA_EXPORTER_RELEASE_TAG }}~ppa1~ubuntu23.10_amd64.deb
+        asset_name: samba-exporter_${{ env.SAMBA_EXPORTER_RELEASE_TAG }}~ppa1~ubuntu23.10_amd64.deb
         asset_content_type: application/zip      
     - name: Upload Release Asset for Debian 12
       uses: actions/upload-release-asset@v1

--- a/build/LaunchpadPublish/Dockerfile.mantic
+++ b/build/LaunchpadPublish/Dockerfile.mantic
@@ -1,0 +1,55 @@
+# ######################################################################################
+# Copyright 2021 by tobi@backfrak.de. All
+# rights reserved. Use of this source code is governed
+# by a BSD-style license that can be found in the
+# LICENSE file.
+# ######################################################################################
+# Container image used by ./../PublishLaunchpadInDocker.sh to transfer the sources to the launchpad-ppa
+# The actual transformation is done by ./PublishLaunchpad.sh when this container get started
+# ######################################################################################
+
+# Use the packages target version (mantic = ubuntu 23.10) as base image
+FROM ubuntu:mantic
+
+# Setup the system and install needed packages
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV TZ="Europe/London"
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y wget \
+                                        curl  \
+                                        libc6  \
+                                        golang-1.20 \
+                                        gzip  \
+                                        ronn\
+                                        debhelper \
+                                        golang-any \
+                                        golang-github-go-kit-kit-dev \
+                                        golang-github-prometheus-client-golang-dev \
+                                        golang-github-prometheus-common-dev \
+                                        golang-gopkg-alecthomas-kingpin.v2-dev \
+                                        golang-github-shirou-gopsutil-dev \  
+                                        dh-golang \
+                                        debhelper \ 
+                                        dh-make \
+                                        lintian \
+                                        git-buildpackage \
+                                        git \
+                                        openssh-client \
+                                        procps \                                      
+                                        gpg
+
+# Copy the script
+COPY PublishLaunchpad.sh /PublishLaunchpad.sh
+RUN chmod 777 /PublishLaunchpad.sh
+
+ARG USER
+ARG UID
+ARG GID
+
+RUN mkdir -p /home/${USER} &&\
+    chmod 770 /home/${USER} && \
+    chown ${UID}:${GID} /home/${USER} 
+
+RUN addgroup --gid ${GID} ${USER} &&\ 
+    adduser --system --quiet --home /home/${USER} --gid ${GID} --uid ${UID} --gecos "builder" ${USER}  || true
+
+RUN id ${UID} && ls -l /home/ 

--- a/build/LaunchpadPublish/PublishLaunchpad.sh
+++ b/build/LaunchpadPublish/PublishLaunchpad.sh
@@ -267,6 +267,15 @@ else
     echo "Not running on lunar 23.04 (lunar)"
 fi
 
+if [ "$distVersionNumber" == "23.10" ] && [ "$distribution" == "Ubuntu" ]; then
+    sed -i "s/focal;/mantic;/g" $WORK_DIR/install/debian/changelog
+    sed -i "s/ubuntu20.04/ubuntu23.10/g" $WORK_DIR/install/debian/changelog
+    sed -i "s/golang-1.16,/golang-1.20,/g" $WORK_DIR/install/debian/control 
+    find . -name "*.go" -exec sed -i "s/github.com\\/shirou\\/gopsutil\\/v3\\/process/github.com\\/shirou\\/gopsutil\\/process/g" {} \;
+else 
+    echo "Not running on lunar 23.10 (mantic)"
+fi
+
 if [ "$distVersionNumber" == "12" ] && [ "$distribution" == "Debian" ]; then
     sed -i "s/focal;/bookworm;/g" $WORK_DIR/install/debian/changelog
     sed -i "s/ubuntu20.04/debian12/g" $WORK_DIR/install/debian/changelog

--- a/build/PublishLaunchpadInDocker.sh
+++ b/build/PublishLaunchpadInDocker.sh
@@ -49,6 +49,9 @@ function buildAndRunDocker() {
     if [ "${distVersion}" == "lunar" ] && [ "$(id -u)" == "1000" ]; then
         userName="ubuntu"
     fi
+    if [ "${distVersion}" == "mantic" ] && [ "$(id -u)" == "1000" ]; then
+        userName="ubuntu"
+    fi
     if [ "$dryRun" == "false" ]; then
         docker run --env LAUNCHPAD_SSH_ID_PUB="$LAUNCHPAD_SSH_ID_PUB" \
             --env LAUNCHPAD_SSH_ID_PRV="$LAUNCHPAD_SSH_ID_PRV"  \
@@ -202,12 +205,12 @@ if [ "$dockerError" == "false" ];then
 fi
 
 if [ "$dockerError" == "false" ];then 
-    echo "Publish tag $tag on launchpad within a docker cotainer for lunar"
+    echo "Publish tag $tag on launchpad within a docker cotainer for mantic"
     echo "# ###################################################################"
-    buildAndRunDocker "lunar"
+    buildAndRunDocker "mantic"
     if [ "$?" != "0" ]; then
         dockerError="true"
-        echo "Error while publish package for lunar"
+        echo "Error while publish package for mantic"
     fi
 fi
 
@@ -220,16 +223,6 @@ if [ "$dockerError" == "false" ];then
         echo "Error while publish package for bullseye"
     fi
 fi
-
-# if [ "$dockerError" == "false" ];then 
-#     echo "Publish tag $tag on launchpad within a docker cotainer for buster"
-#     echo "# ###################################################################"
-#     buildAndRunDocker "buster"
-#     if [ "$?" != "0" ]; then
-#         dockerError="true"
-#         echo "Error while publish package for buster"
-#     fi
-# fi
 
 if [ "$dockerError" == "false" ];then 
     echo "Publish tag $tag on launchpad within a docker cotainer for bookworm"

--- a/build/PublishRpmInDocker.sh
+++ b/build/PublishRpmInDocker.sh
@@ -190,23 +190,15 @@ if [ "$dockerError" == "false" ];then
     fi
 fi
 
-# if [ "$dockerError" == "false" ];then 
-#     echo "Publish tag $tag on corp within a docker cotainer for fedora 36"
-#     echo "# ###################################################################"
-#     buildAndRunDocker "fedora36"
-#     if [ "$?" != "0" ]; then
-#         dockerError="true"
-#          echo "Error while publish for fedora 36"
-#     fi
-# fi
+
 
 if [ "$dockerError" == "false" ];then 
-    echo "Publish tag $tag on corp within a docker cotainer for fedora 37"
+    echo "Publish tag $tag on corp within a docker cotainer for fedora 39"
     echo "# ###################################################################"
-    buildAndRunDocker "fedora37"
+    buildAndRunDocker "fedora39"
     if [ "$?" != "0" ]; then
         dockerError="true"
-         echo "Error while publish for fedora 37"
+         echo "Error while publish for fedora 39"
     fi
 fi
 

--- a/build/rpm-build/Dockerfile
+++ b/build/rpm-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:39
 
 RUN yum -y update && \
     yum clean all

--- a/build/rpm-publish/Dockerfile.fedora39
+++ b/build/rpm-publish/Dockerfile.fedora39
@@ -1,0 +1,51 @@
+# ######################################################################################
+# Copyright 2021 by tobi@backfrak.de. All
+# rights reserved. Use of this source code is governed
+# by a BSD-style license that can be found in the
+# LICENSE file.
+# ######################################################################################
+# Container image used by ./../PublishRpmInDocker.sh to transfer the sources to the launchpad-ppa
+# The actual transformation is done by ./RpmPublish.sh when this container get started
+# ######################################################################################
+
+FROM fedora:39
+
+RUN dnf -y update && \
+    dnf install -y 'dnf-command(builddep)' \
+        redhat-lsb \
+        rubygem-ronn-ng \
+        rpmdevtools \
+        rpmlint \
+        rpm-build \
+        rpm-sign \
+        gzip \
+        curl \
+        man-db \
+        binutils \
+        wget \
+        git \
+        go-rpm-macros \                                        
+        openssh-clients \
+        copr-cli \
+        procps-ng \
+        gnupg && \
+    dnf clean all
+
+COPY samba-exporter.from_source.spec /samba-exporter.from_source.spec
+
+RUN dnf builddep --spec /samba-exporter.from_source.spec -y && \
+    dnf clean all
+
+ARG USER
+ARG UID
+ARG GID
+
+# Add publish script
+COPY RpmPublish.sh /RpmPublish.sh
+RUN chmod 777 /RpmPublish.sh
+
+RUN mkdir -p /home/${USER} &&\
+    chmod 770 /home/${USER} && \
+    chown ${UID}:${GID} /home/${USER} && \
+    chmod 777 /var/lib/rpm/
+

--- a/build/rpm-publish/RpmPublish.sh
+++ b/build/rpm-publish/RpmPublish.sh
@@ -296,6 +296,16 @@ else
     echo "Not running on Fedora 38"
 fi
 
+if [ "$distribution" == "Fedora" ] && [ "$distVersionNumber" == "39" ]; then
+    echo "Do modifications for 'Fedora 39'"
+    sed -i "s/Release: 1/Release: 1.fc39/g" ~/rpmbuild/SPECS/samba-exporter.spec
+    buildSystem="rpm"
+    changeroots="--chroot fedora-${distVersionNumber}-x86_64"
+    coprUpload="true"
+else
+    echo "Not running on Fedora 39"
+fi
+
 echo "# ###################################################################"
 echo "~/rpmbuild/SPECS/samba-exporter.spec after modification"
 echo "# ###################################################################"

--- a/docs/Installation/SupportedVersions.md
+++ b/docs/Installation/SupportedVersions.md
@@ -11,7 +11,7 @@
 | Ubnutu 21.10   | Impish Indri | no |
 | Ubnutu 22.04   | Jammy Jellyfish | yes |
 | Ubnutu 22.10  | Kinetic Kudu | no |
-| Ubnutu 23.04  | Lunar Lobster | yes |
+| Ubnutu 23.04  | Lunar Lobster | no |
 | Ubnutu 23.10  | Mantic Minotaur | yes |
 | Ubnutu 24.04  | -| planed |
 
@@ -42,9 +42,10 @@
 | Fedora 34  | 2021-04-27 | no |
 | Fedora 35  | 2021-11-02 | yes |
 | Fedora 36   | 2022-04-19 | no |
-| Fedora 37   | 2022-11-15 | yes |
+| Fedora 37   | 2022-11-15 | no |
 | Fedora 38   | 2023-04-25 | yes |
-| Fedora 39   | 2023-10-24 | planed |
+| Fedora 39   | 2023-10-24 | yes |
+| Fedora 20   | xxx | planed |
 
 ---
 

--- a/docs/Installation/SupportedVersions.md
+++ b/docs/Installation/SupportedVersions.md
@@ -12,7 +12,8 @@
 | Ubnutu 22.04   | Jammy Jellyfish | yes |
 | Ubnutu 22.10  | Kinetic Kudu | no |
 | Ubnutu 23.04  | Lunar Lobster | yes |
-| Ubnutu 23.10  | Mantic Minotaur | planed |
+| Ubnutu 23.10  | Mantic Minotaur | yes |
+| Ubnutu 24.04  | -| planed |
 
 ---
 


### PR DESCRIPTION
This contains the needed changes to get packages for [Ubuntu 23.10 (Mantic Minotaur)](https://releases.ubuntu.com/mantic/) and [Fedora 39](https://docs.fedoraproject.org/en-US/releases/f39/) and will close the bugs #120 and #121

