### PR TITLE
fix(example): grafana legend typo Loks->Locks

### DIFF
--- a/src/example/grafana/SambaService.json
+++ b/src/example/grafana/SambaService.json
@@ -164,7 +164,7 @@
           "exemplar": true,
           "expr": "samba_locks_per_share_count{instance=\"${SAMBA_SERVER}\"}",
           "interval": "",
-          "legendFormat": "Loks on  {{share}}",
+          "legendFormat": "Locks on  {{share}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Simple typo I noticed on the Grafana dashboard