### PR TITLE
Set smbstatus output language to English

### DIFF
--- a/src/tobi.backfrak.de/cmd/samba_statusd/main.go
+++ b/src/tobi.backfrak.de/cmd/samba_statusd/main.go
@@ -97,6 +97,8 @@ func realMain() int {
 			logger.WriteErrorMessage("Can not find \"smbstatus\" executable. Please install the needed package.")
 			return -3
 		} else {
+			// Set the output language to English
+			smbstatusPath = "LANG=en_US.UTF-8 " + smbstatusPath
 			logger.WriteVerbose(fmt.Sprintf("Use %s to get samba status.", smbstatusPath))
 		}
 


### PR DESCRIPTION
When executing substatus in a non-English environment, the output format differs from the English format, which can lead to time parsing failure.